### PR TITLE
#165965575 #165965570 Add purchase and sales history pages-ui

### DIFF
--- a/UI/css/admin.css
+++ b/UI/css/admin.css
@@ -14,10 +14,6 @@
 	position: relative;
 	text-align: left;
 }
-h3.c-details-list {
-	text-align: left;
-	margin: 0;
-}
 .car-info p {
 	margin: 0;
 }

--- a/UI/css/general.css
+++ b/UI/css/general.css
@@ -127,13 +127,14 @@ footer {
 }
 .input-field label{
 	opacity: 1.0;
-	font-size: 14px;
+	font-size: 1rem;
 	margin-bottom: 2px;
 }
 .input-field textarea,
 .input-field select,
 .input-field input{
 	width: 100%;
+	font-size: 1.5rem;
 	display: block;
 	border: none;
 	outline: none;

--- a/UI/css/general.css
+++ b/UI/css/general.css
@@ -230,6 +230,10 @@ footer {
 	padding: 15px;
 	text-align: center;
 }
+h3.c-details-list {
+	text-align: left;
+	margin: 0;
+}
 .car-price {
 	font-size: 2rem;
 	margin: 0;

--- a/UI/css/general.css
+++ b/UI/css/general.css
@@ -40,6 +40,28 @@ a:hover {
 li.current a:hover {
 	text-decoration: none;
 }
+.dropdown {
+	position: relative;
+}
+.dropdown:hover ul.dropdown-list {
+	display: block;
+}
+ul.dropdown-list {
+	position: absolute;
+	display: none;
+	width: 180px;
+	top: 40px;
+	background-color: #000;
+	color: #fff;
+	z-index: 101;
+}
+.dropdown-list li {
+	
+}
+.dropdown-list li a:hover {
+	color: #fff;
+}
+
 
 /*General containers styling*/
 header {

--- a/UI/css/general.css
+++ b/UI/css/general.css
@@ -108,6 +108,11 @@ footer {
 .delete:hover {
 	background-color: #B71513;
 }
+button[disabled],
+button[disabled]:hover {
+	background-color: #888;
+	cursor: default;
+}
 .btn-group {}
 .full-btn {
 	width: 100%;

--- a/UI/css/history.css
+++ b/UI/css/history.css
@@ -1,0 +1,50 @@
+h2 {
+	text-align: center;
+}
+.history-list {
+	max-width: 1000px;
+	margin: 0 auto;
+	background-color: #fff;
+	list-style: none;
+	padding: 15px;
+}
+.history-list-item {
+	border: 2px solid #eee;
+	margin-bottom: 10px;
+}
+.history-list-item:hover {
+	background-color: #eee;
+	border: 2px solid #fff;
+}
+.history-list-item:hover .purchase-date {
+	border-right: 2px solid #fff;
+}
+.history-list-item:hover .user-actions {
+	border-left: 2px solid #fff;
+}
+.purchase-date {
+	width: 20%;
+	border-right: 2px solid #eee;
+}
+.purchase-details {
+	width: 55%;
+	position: relative;
+}
+.purchase-info {
+	margin: 5px 0 0;
+	text-align: left;
+}
+.status {
+	position: absolute;
+	bottom: 15px;
+	right: 15px;
+	background-color: #FEBD2D;
+	padding: 5px 10px;
+}
+.user-actions {
+	width: 25%;
+	border-left: 2px solid #eee;
+}
+.p-15 {
+	padding: 15px;
+}

--- a/UI/css/marketplace.css
+++ b/UI/css/marketplace.css
@@ -3,3 +3,6 @@
 	background-color: #fff;
 	margin-bottom: 30px;
 }
+.car-image {
+	cursor: pointer;
+}

--- a/UI/html-pages/marketplace.html
+++ b/UI/html-pages/marketplace.html
@@ -21,7 +21,12 @@
 						<li><a href="#">Post New AD</a></li>
 						<li class="current"><a href="./marketplace.html">Marketplace</a></li>
 						<li><a href="./my-posted-ads.html">My ADs</a></li>
-						<li><a href="#">History</a></li>
+						<li class="dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
+							<ul class="dropdown-list"></a>
+								<li><a href="./sales-history.html">Sales History</a></li>
+								<li><a href="./purchase-history.html">Purchase History</a></li>
+							</ul>
+						</li>
 						<li><a href="./index.html">Logout</a></li>
 					</ul>
 				</nav>

--- a/UI/html-pages/marketplace.html
+++ b/UI/html-pages/marketplace.html
@@ -167,7 +167,7 @@
 					<ul class="car-list flex-container">
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-1.jpg">
+								<img src="../images/car-samples/car-sample-1.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -178,7 +178,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-2.jpg">
+								<img src="../images/car-samples/car-sample-2.jpg" title="Preview AD">
 								<label class="car-state-tag">Used</label>
 							</div>
 							<div class="car-info">
@@ -189,7 +189,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-3.jpg">
+								<img src="../images/car-samples/car-sample-3.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -200,7 +200,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-4.jpg">
+								<img src="../images/car-samples/car-sample-4.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -211,7 +211,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-5.jpg">
+								<img src="../images/car-samples/car-sample-5.jpg" title="Preview AD">
 								<label class="car-state-tag">Used</label>
 							</div>
 							<div class="car-info">
@@ -222,7 +222,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-6.jpg">
+								<img src="../images/car-samples/car-sample-6.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -233,7 +233,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-7.jpg">
+								<img src="../images/car-samples/car-sample-7.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -244,7 +244,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-8.jpg">
+								<img src="../images/car-samples/car-sample-8.jpg" title="Preview AD">
 								<label class="car-state-tag">Used</label>
 							</div>
 							<div class="car-info">
@@ -255,7 +255,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-9.jpg">
+								<img src="../images/car-samples/car-sample-9.jpg" title="Preview AD">
 								<label class="car-state-tag">Used</label>
 							</div>
 							<div class="car-info">
@@ -266,7 +266,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-10.jpg">
+								<img src="../images/car-samples/car-sample-10.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -277,7 +277,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-11.jpg">
+								<img src="../images/car-samples/car-sample-11.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">
@@ -288,7 +288,7 @@
 						</li>
 						<li class="car-list-item">
 							<div class="car-image">
-								<img src="../images/car-samples/car-sample-12.jpg">
+								<img src="../images/car-samples/car-sample-12.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
 							</div>
 							<div class="car-info">

--- a/UI/html-pages/marketplace.html
+++ b/UI/html-pages/marketplace.html
@@ -369,7 +369,7 @@
 		</div>
 
 		<!-- Modal view for flagging/report a posted AD as fraudulent -->
-		<div id="fraudulent-flag-overlay" class="overlay" >
+		<div id="fraudulent-flag-overlay" class="overlay" style="display: none">
 			<div class="modal-view sm-m-v">
 				<h2 class="modal-header">Mark AD as Fradulent</h2>
 				<div class="modal-body">

--- a/UI/html-pages/my-posted-ads.html
+++ b/UI/html-pages/my-posted-ads.html
@@ -22,7 +22,12 @@
 						<li><a href="#">Post New AD</a></li>
 						<li><a href="./marketplace.html">Marketplace</a></li>
 						<li class="current"><a href="./my-posted-ads.html">My ADs</a></li>
-						<li><a href="#">History</a></li>
+						<li class="dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
+							<ul class="dropdown-list"></a>
+								<li><a href="./sales-history.html">Sales History</a></li>
+								<li><a href="./purchase-history.html">Purchase History</a></li>
+							</ul>
+						</li>
 						<li><a href="./index.html">Logout</a></li>
 					</ul>
 				</nav>

--- a/UI/html-pages/purchase-history.html
+++ b/UI/html-pages/purchase-history.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width initial-scale=1.0">
+		<meta name="description" content="Auto Mart is an online marketplace for automobiles of diverse makes, model or body type. With Auto Mart, users can sell their cars or buy from trusted dealerships or private sellers.">
+		<title>Purchase History - Auto Mart</title>
+
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css">
+		<link href="../css/general.css" rel="stylesheet">
+		<link href="../css/history.css" rel="stylesheet">
+		
+		<link rel="icon" type="image/x-icon" href="../images/favicon.ico">
+	</head>
+	<body>
+		<div class="container">
+			<header>
+				<nav>
+					<a href="./index.html"><img src="../images/automart-full-logo-150px.png"></a>
+					<ul>
+						<li><a href="#">Post New AD</a></li>
+						<li><a href="./marketplace.html">Marketplace</a></li>
+						<li><a href="./my-posted-ads.html">My ADs</a></li>
+						<li class="current"><a href="#">History</a></li>
+						<li><a href="./index.html">Logout</a></li>
+					</ul>
+				</nav>
+			</header>
+
+			<div class="content">
+				<main class="main-100">
+					<h2>My Purchase History</h2>
+					<ul class="history-list">
+						<li class="history-list-item flex-container">
+							<div class="purchase-date p-15">
+								<p>24 Jan 2019<br>3:23pm</p>
+							</div>
+							<div class="purchase-details p-15">
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">Volvo Highlander Dx @ &#8358 5,200,000</p>
+								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
+								<label class="status">Pending</label>
+							</div>
+							<div class="user-actions p-15">
+								<button class="order full-btn btn">Update Price</button>
+							</div>
+						</li>
+						<li class="history-list-item flex-container">
+							<div class="purchase-date p-15">
+								<p>24 Jan 2019<br>3:23pm</p>
+							</div>
+							<div class="purchase-details p-15">
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">Volvo Highlander Dx @ &#8358 5,200,000</p>
+								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
+								<label class="status">Pending</label>
+							</div>
+							<div class="user-actions p-15">
+								<button class="order full-btn btn">Update Price</button>
+							</div>
+						</li>
+						<li class="history-list-item flex-container">
+							<div class="purchase-date p-15">
+								<p>24 Jan 2019<br>3:23pm</p>
+							</div>
+							<div class="purchase-details p-15">
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">Volvo Highlander Dx @ &#8358 5,200,000</p>
+								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
+								<label class="status">Pending</label>
+							</div>
+							<div class="user-actions p-15">
+								<button class="order full-btn btn">Update Price</button>
+							</div>
+						</li>
+					</ul>
+				</main>
+			</div>
+			
+			<footer>
+				<div>
+					<p>Auto-Mart 2019</p>
+					<p>Chukwunonso did it.</p>
+				</div>
+			</footer>
+		</div>
+
+	</body>
+</html>

--- a/UI/html-pages/purchase-history.html
+++ b/UI/html-pages/purchase-history.html
@@ -21,7 +21,12 @@
 						<li><a href="#">Post New AD</a></li>
 						<li><a href="./marketplace.html">Marketplace</a></li>
 						<li><a href="./my-posted-ads.html">My ADs</a></li>
-						<li class="current"><a href="#">History</a></li>
+						<li class="current dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
+							<ul class="dropdown-list"></a>
+								<li><a href="./sales-history.html">Sales History</a></li>
+								<li><a href="./purchase-history.html">Purchase History</a></li>
+							</ul>
+						</li>
 						<li><a href="./index.html">Logout</a></li>
 					</ul>
 				</nav>

--- a/UI/html-pages/purchase-history.html
+++ b/UI/html-pages/purchase-history.html
@@ -85,5 +85,27 @@
 			</footer>
 		</div>
 
+		<!-- Modal view to update price for Purchase order -->
+		<div id="update-price-overlay" class="overlay">
+			<div class="modal-view sm-m-v">
+				<h2 class="modal-header">Update Purchase Price</h2>
+				<div class="modal-body">
+					<h3 id="c-details" class="c-details-mv">New Volkswagen Cx3 - 2001</h3>
+					<p id="body-type" class="c-b-type">(Large Van)</p>
+					<p id="car-price" class="c-price">Price: &#8358 13,000,000</p><hr>
+					<p id="car-price" class="c-price">Current Offered Price:<br>&#8358 11,500,000</p>
+					<form>
+						<div class = "input-field single">
+							<label for="">New Offering Price(&#8358):</label><br>
+							<input type="number" min="1000" name="offering-price" placeholder="Offering Price(&#8358):">
+						</div>
+						<div class="btn-group flex-container">
+							<input type="submit" class="half-btn btn" name="" id="place-order half-btn" value="Update Price">
+							<button class="half-btn btn">Cancel</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
 	</body>
 </html>

--- a/UI/html-pages/sales-history.html
+++ b/UI/html-pages/sales-history.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width initial-scale=1.0">
 		<meta name="description" content="Auto Mart is an online marketplace for automobiles of diverse makes, model or body type. With Auto Mart, users can sell their cars or buy from trusted dealerships or private sellers.">
-		<title>Purchase History - Auto Mart</title>
+		<title>Sales History - Auto Mart</title>
 
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css">
 		<link href="../css/general.css" rel="stylesheet">
@@ -29,20 +29,21 @@
 
 			<div class="content">
 				<main class="main-100">
-					<h2>My Purchase History</h2>
+					<h2>My Sales Order History</h2>
 					<ul class="history-list">
 						<li class="history-list-item flex-container">
 							<div class="purchase-date p-15">
 								<p>24 Jan 2019<br>3:23pm</p>
 							</div>
 							<div class="purchase-details p-15">
-								<h3 class="c-details-list">Purchase Order for Volvo Highlander Dx</h3>
-								<p class="purchase-info">Actual Price: &#8358 5,200,000. Owner: John Ebuka</p>
-								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">For Volvo Highlander Dx @ &#8358 5,200,000 (Actual Price)</p>
+								<p class="purchase-info">Price Offered: &#8358 3,500,000</p>
 								<label class="status">Pending</label>
 							</div>
 							<div class="user-actions p-15">
-								<button class="order full-btn btn">Update Price</button>
+								<button class="order full-btn btn">Accept Offer</button>
+								<button class="delete full-btn btn">Decline Offer</button>
 							</div>
 						</li>
 						<li class="history-list-item flex-container">
@@ -50,27 +51,44 @@
 								<p>24 Jan 2019<br>3:23pm</p>
 							</div>
 							<div class="purchase-details p-15">
-								<h3 class="c-details-list">Purchase Order for Volvo Highlander Dx</h3>
-								<p class="purchase-info">Actual Price: &#8358 5,200,000. Owner: John Ebuka</p>
-								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">For Volvo Highlander Dx @ &#8358 5,200,000 (Actual Price)</p>
+								<p class="purchase-info">Price Offered: &#8358 3,500,000</p>
+								<label class="status">Accpeted</label>
+							</div>
+							<div class="user-actions p-15">
+								<button class="order full-btn btn" disabled>Accept Offer</button>
+								<button class="delete full-btn btn" disabled>Decline Offer</button>
+							</div>
+						</li>
+						<li class="history-list-item flex-container">
+							<div class="purchase-date p-15">
+								<p>24 Jan 2019<br>3:23pm</p>
+							</div>
+							<div class="purchase-details p-15">
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">For Volvo Highlander Dx @ &#8358 5,200,000 (Actual Price)</p>
+								<p class="purchase-info">Price Offered: &#8358 3,500,000</p>
+								<label class="status">Pending</label>
+							</div>
+							<div class="user-actions p-15">
+								<button class="order full-btn btn">Accept Offer</button>
+								<button class="delete full-btn btn">Decline Offer</button>
+							</div>
+						</li>
+						<li class="history-list-item flex-container">
+							<div class="purchase-date p-15">
+								<p>24 Jan 2019<br>3:23pm</p>
+							</div>
+							<div class="purchase-details p-15">
+								<h3 class="c-details-list">Purchase Order from John Ebuka</h3>
+								<p class="purchase-info">For Volvo Highlander Dx @ &#8358 5,200,000 (Actual Price)</p>
+								<p class="purchase-info">Price Offered: &#8358 3,500,000</p>
 								<label class="status">Rejected</label>
 							</div>
 							<div class="user-actions p-15">
-								<button class="order full-btn btn" disabled>Update Price</button>
-							</div>
-						</li>
-						<li class="history-list-item flex-container">
-							<div class="purchase-date p-15">
-								<p>24 Jan 2019<br>3:23pm</p>
-							</div>
-							<div class="purchase-details p-15">
-								<h3 class="c-details-list">Purchase Order for Volvo Highlander Dx</h3>
-								<p class="purchase-info">Actual Price: &#8358 5,200,000. Owner: John Ebuka</p>
-								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
-								<label class="status">Pending</label>
-							</div>
-							<div class="user-actions p-15">
-								<button class="order full-btn btn">Update Price</button>
+								<button class="order full-btn btn" disabled>Accept Offer</button>
+								<button class="delete full-btn btn" disabled>Decline Offer</button>
 							</div>
 						</li>
 					</ul>
@@ -83,29 +101,6 @@
 					<p>Chukwunonso did it.</p>
 				</div>
 			</footer>
-		</div>
-
-		<!-- Modal view to update price for Purchase order -->
-		<div id="update-price-overlay" class="overlay" style="display: none">
-			<div class="modal-view sm-m-v">
-				<h2 class="modal-header">Update Purchase Price</h2>
-				<div class="modal-body">
-					<h3 id="c-details" class="c-details-mv">New Volkswagen Cx3 - 2001</h3>
-					<p id="body-type" class="c-b-type">(Large Van)</p>
-					<p id="car-price" class="c-price">Price: &#8358 13,000,000</p><hr>
-					<p id="car-price" class="c-price">Current Offered Price:<br>&#8358 11,500,000</p>
-					<form>
-						<div class = "input-field single">
-							<label for="">New Offering Price(&#8358):</label><br>
-							<input type="number" min="1000" name="offering-price" placeholder="Offering Price(&#8358):">
-						</div>
-						<div class="btn-group flex-container">
-							<input type="submit" class="half-btn btn" name="" id="place-order half-btn" value="Update Price">
-							<button class="half-btn btn">Cancel</button>
-						</div>
-					</form>
-				</div>
-			</div>
 		</div>
 	</body>
 </html>

--- a/UI/html-pages/sales-history.html
+++ b/UI/html-pages/sales-history.html
@@ -21,7 +21,12 @@
 						<li><a href="#">Post New AD</a></li>
 						<li><a href="./marketplace.html">Marketplace</a></li>
 						<li><a href="./my-posted-ads.html">My ADs</a></li>
-						<li class="current"><a href="#">History</a></li>
+						<li class="current dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
+							<ul class="dropdown-list"></a>
+								<li><a href="./sales-history.html">Sales History</a></li>
+								<li><a href="./purchase-history.html">Purchase History</a></li>
+							</ul>
+						</li>
 						<li><a href="./index.html">Logout</a></li>
 					</ul>
 				</nav>


### PR DESCRIPTION
#### What does this PR do?
Add purchase history page where a user can view his/her purchase history, and can also update the price of a purchase offer that is still pending.
Add a sales history page where a user can view his sales history, and can also accept or reject an offer for his/her posted ADs.
Make the History button on the navbar a dropdown which includes link to sales and purchase history.