### PR TITLE
#166438311 Activate user purchase order history page

### DIFF
--- a/UI/css/general.css
+++ b/UI/css/general.css
@@ -407,7 +407,8 @@ h3.c-details-mv {
   text-align: center;
   font-size: 1.3rem;
 }
-.c-price {
+.c-price,
+.c-c-o-price {
   text-align: center;
   font-size: 2rem;
   margin: 0;

--- a/UI/js/marketplace.js
+++ b/UI/js/marketplace.js
@@ -38,16 +38,16 @@ const openPurchaseModal = (params) => {
   const {
     id, name, price, body_type,
   } = params;
-  const PlaceOrderBtn = document.getElementById('place-order');
+  const placeOrderBtn = document.getElementById('place-order');
 
-  document.querySelector('#purchase-order-overlay #c-details').innerHTML = name;
-  document.querySelector('#purchase-order-overlay #body-type').innerHTML = `(${body_type})`;
-  document.querySelector('#purchase-order-overlay #car-price').innerHTML = `&#8358 ${price.toLocaleString('en-US')}`;
+  document.querySelector('#purchase-order-overlay .c-details-mv').innerHTML = name;
+  document.querySelector('#purchase-order-overlay .c-b-type').innerHTML = `(${body_type})`;
+  document.querySelector('#purchase-order-overlay .c-price').innerHTML = `&#8358 ${price.toLocaleString('en-US')}`;
 
   purchaseModal.style.display = 'block';
   toggleScroll();
 
-  PlaceOrderBtn.onclick = (e) => {
+  placeOrderBtn.onclick = (e) => {
     e.preventDefault();
     let price_offered = document.querySelector('.purchase-order-form .price').value;
     price_offered = price_offered.replace(/\D/g, '');
@@ -64,7 +64,7 @@ const openPurchaseModal = (params) => {
       const message = document.querySelector('#notification-overlay .message');
       const res = response;
       if (res.status === 201) {
-        message.innerHTML = `You have successfully placed an order for ${res.data.car_name}.<br/>
+        message.innerHTML = `You have successfully placed an order for <b>${res.data.car_name}</b>.<br/><br/>
         Actual Price: &#8358 ${res.data.price.toLocaleString('en-US')}<br/>
         Price Offered: &#8358 ${res.data.price_offered.toLocaleString('en-US')}`;
       } else {

--- a/UI/js/purchase-history.js
+++ b/UI/js/purchase-history.js
@@ -1,16 +1,91 @@
-const openUpdateModalBtns = document.querySelectorAll('.update-p');
 const updatePriceModal = document.getElementById('update-price-overlay');
 const closeUpdateModal = document.getElementById('close-update-modal');
+const notificationModal = document.getElementById('notification-overlay');
+const closeNotifation = document.querySelector('.close-notification');
 
-openUpdateModalBtns.forEach((btn) => {
-  btn.onclick = () => {
-    updatePriceModal.style.display = 'block';
+const user_id = sessionStorage.getItem('user_id');
+const is_loggedin = sessionStorage.getItem('is_loggedin');
+
+const openUpdateModal = (params) => {
+	// logic for updating price of an order
+};
+
+window.onload = () => {
+	// redirect to sign in page if the user is not logged in
+  if (!is_loggedin) {
+			setTimeout(() => {
+			window.location.href = '/api/v1/signin';
+		}, 0);
+  }
+
+  // fetch the purchase orders from database and populate the purchase history page
+   fetch(`/api/v1/order?user_id=${user_id}`)
+  .then(res => res.json())
+  .then((response) => {
+    const res = response;
+    const historyList = document.querySelector('.history-list');
+    if (res.data.purchase_list.length > 0) {
+      res.data.purchase_list.map((order) => {
+        const {
+          id, car_name, car_body_type, price, owner_name,
+          buyer_id, price_offered, created_on, status,
+        } = order;
+        const orderCard = document.createElement('li');
+        const btnGrp = document.createElement('div');
+        const updateOrderBtn = document.createElement('button');
+        const cancelOrderBtn = document.createElement('button');
+
+        orderCard.setAttribute('class', 'history-list-item flex-container');
+        orderCard.innerHTML = `<div class="purchase-date p-15">
+																<p>${created_on}</p>
+																<label class="status">${status}</label>
+															</div>
+															<div class="purchase-details p-15">
+																<h3 class="c-details-list">Purchase Order for ${car_name}</h3>
+																<p class="purchase-info">Actual Price: &#8358 ${price.toLocaleString('en-US')}.
+																Owner: ${owner_name}</p>
+																<p class="purchase-info">Price Offered: &#8358 ${price_offered.toLocaleString('en-US')}</p>
+															</div>`;
+				btnGrp.setAttribute('class', 'user-actions p-15');
+				updateOrderBtn.setAttribute('class', 'update-p full-btn btn');
+				updateOrderBtn.innerHTML = 'Update Price';
+				updateOrderBtn.onclick = () => {
+					openUpdateModal({
+						id, car_name, price, car_body_type, price_offered,
+					});
+				};
+				cancelOrderBtn.setAttribute('class', 'delete full-btn btn');
+				cancelOrderBtn.innerHTML = 'Cancel Purchase';
+
+				btnGrp.appendChild(updateOrderBtn);
+				btnGrp.appendChild(cancelOrderBtn);
+
+				orderCard.appendChild(btnGrp);
+				historyList.appendChild(orderCard);
+				return 0;
+      });
+    } else {
+      // the car list is empty
+      historyList.style.textAlign = 'center';
+      historyList.innerHTML = 'You have not placed any order yet!';
+    }
+  })
+  .catch((error) => {
+    const message = document.querySelector('#notification-overlay .message');
+    message.innerHTML = error;
+    notificationModal.style.display = 'block';
     toggleScroll();
-  };
-});
+  });
+};
 
 closeUpdateModal.onclick = (e) => {
   e.preventDefault();
   updatePriceModal.style.display = 'none';
   toggleScroll();
+};
+
+closeNotifation.onclick = (e) => {
+  e.preventDefault();
+  notificationModal.style.display = 'none';
+  document.location.reload();
 };

--- a/UI/template/marketplace.html
+++ b/UI/template/marketplace.html
@@ -295,7 +295,7 @@
 			</div>
 		</div>
 
-		<!-- Modal view for flagging/report a posted AD as fraudulent -->
+		<!-- Modal view for All Notifications -->
 		<div id="notification-overlay" class="overlay">
 			<div class="modal-view sm-m-v">
 				<h2 class="modal-header">Notification</h2>

--- a/UI/template/purchase-history.html
+++ b/UI/template/purchase-history.html
@@ -25,7 +25,7 @@
 							<li><a href="./post-new-ad">Post New AD</a></li>
 							<li><a href="./marketplace">Marketplace</a></li>
 							<li><a href="./my-posted-ads">My ADs</a></li>
-							<li class="current" class="dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
+							<li class="current dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
 								<ul class="dropdown-list"></a>
 									<li><a href="./sales-history">Sales History</a></li>
 									<li class="here"><a href="./purchase-history">Purchase History</a></li>
@@ -41,7 +41,7 @@
 				<main class="main-100">
 					<h2>My Purchase History</h2>
 					<ul class="history-list">
-						<li class="history-list-item flex-container">
+						<!-- <li class="history-list-item flex-container">
 							<div class="purchase-date p-15">
 								<p>24 Jan 2019<br>3:23pm</p>
 								<label class="status">Pending</label>
@@ -55,37 +55,7 @@
 								<button class="update-p full-btn btn">Update Price</button>
 								<button class="delete full-btn btn">Cancel Purchase</button>
 							</div>
-						</li>
-						<li class="history-list-item flex-container">
-							<div class="purchase-date p-15">
-								<p>24 Jan 2019<br>3:23pm</p>
-								<label class="status">Rejected</label>
-							</div>
-							<div class="purchase-details p-15">
-								<h3 class="c-details-list">Purchase Order for Volvo Highlander Dx</h3>
-								<p class="purchase-info">Actual Price: &#8358 5,200,000. Owner: John Ebuka</p>
-								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
-							</div>
-							<div class="user-actions p-15">
-								<button class="update-p full-btn btn" disabled>Update Price</button>
-								<button class="delete full-btn btn" disabled>Cancel Purchase</button>
-							</div>
-						</li>
-						<li class="history-list-item flex-container">
-							<div class="purchase-date p-15">
-								<p>24 Jan 2019<br>3:23pm</p>
-								<label class="status">Pending</label>
-							</div>
-							<div class="purchase-details p-15">
-								<h3 class="c-details-list">Purchase Order for Volvo Highlander Dx</h3>
-								<p class="purchase-info">Actual Price: &#8358 5,200,000. Owner: John Ebuka</p>
-								<p class="purchase-info">Price Offered: &#8358 5,200,000</p>
-							</div>
-							<div class="user-actions p-15">
-								<button class="update-p full-btn btn">Update Price</button>
-								<button class="delete full-btn btn">Cancel Purchase</button>
-							</div>
-						</li>
+						</li> -->
 					</ul>
 				</main>
 			</div>
@@ -107,24 +77,35 @@
 		</div>
 
 		<!-- Modal view to update price for Purchase order -->
-		<div id="update-price-overlay" class="overlay" style="display: none">
+		<div id="update-price-overlay" class="overlay">
 			<div class="modal-view sm-m-v">
 				<h2 class="modal-header">Update Purchase Price</h2>
 				<div class="modal-body">
-					<h3 id="c-details" class="c-details-mv">New Volkswagen Cx3 - 2001</h3>
-					<p id="body-type" class="c-b-type">(Large Van)</p>
-					<p id="car-price" class="c-price">Price: &#8358 13,000,000</p><hr>
-					<p id="car-price" class="c-price">Current Price Offered:<br>&#8358 11,500,000</p>
-					<form>
+					<h3 id="c-details" class="c-details-mv"></h3>
+					<p id="body-type" class="c-b-type"></p>
+					<p id="car-price" class="c-price"></p><hr>
+					<p id="car-price" class="c-c-o-price"></p>
+					<form class="update-order-form">
 						<div class = "input-field single">
-							<label for="">New Offering Price(&#8358):</label><br>
-							<input type="number" min="1000" name="offering-price" placeholder="Offering Price(&#8358):">
+							<label>New Offering Price(&#8358):</label><br>
+							<input type="text" data-type="number" min="1000" class="price" placeholder="Offering Price(&#8358):">
 						</div>
 						<div class="btn-group flex-container">
 							<button id="update-price" class="half-btn btn">Update Price</button>
 							<button id="close-update-modal" class="half-btn btn">Cancel</button>
 						</div>
 					</form>
+				</div>
+			</div>
+		</div>
+
+		<!-- Modal view for All Notifications -->
+		<div id="notification-overlay" class="overlay">
+			<div class="modal-view sm-m-v">
+				<h2 class="modal-header">Notification</h2>
+				<div class="modal-body">
+					<div class="message"></div>
+					<button class="full-btn btn close-notification">Close</button>
 				</div>
 			</div>
 		</div>

--- a/UI/template/sales-history.html
+++ b/UI/template/sales-history.html
@@ -25,7 +25,7 @@
 							<li><a href="./post-new-ad">Post New AD</a></li>
 							<li><a href="./marketplace">Marketplace</a></li>
 							<li><a href="./my-posted-ads">My ADs</a></li>
-							<li class="current" class="dropdown"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
+							<li class="dropdown current"><a href="javascript:void(0)">History <i class="fa fa-caret-down"></i></a>
 								<ul class="dropdown-list"></a>
 									<li class="here"><a href="./sales-history">Sales History</a></li>
 									<li><a href="./purchase-history">Purchase History</a></li>

--- a/api/v1/controllers/orders.js
+++ b/api/v1/controllers/orders.js
@@ -2,6 +2,8 @@ import orders from '../models/orders';
 import users from '../models/users';
 import cars from '../models/cars';
 
+import util from '../util';
+
 export default {
 	/* returns 2 lists for a user.
 		purchase list, which contains the user's purchase
@@ -10,7 +12,7 @@ export default {
 		any of is posted sales ad, it returns empty arrays.
 	*/
 	getAllOrders(req, res) {
-		const user = users.getAUserById(parseInt(req.body.user_id, 10));
+		const user = users.getAUserById(parseInt(req.query.user_id, 10));
 		const ordersList = orders.getAllOrders();
 		const purchaseList = [];
 		const salesList = [];
@@ -50,6 +52,7 @@ export default {
 		const newOrder = orders.createNewOrder({
 			car_id: parseInt(car_id, 10),
 			car_name: car.name,
+			car_body_type: car.body_type,
 			price: car.price,
 			owner_id: car.owner_id,
 			owner_name: car.owner_name,
@@ -57,7 +60,7 @@ export default {
 			buyer_name: `${first_name} ${last_name.charAt(0)}.`,
 			price_offered: parseFloat(price_offered),
 			status: 'pending',
-			created_on: Date(),
+			created_on: util.getDate(),
 		});
 		return res.status(201).send({ status: 201, data: newOrder });
 	},

--- a/api/v1/models/orders.js
+++ b/api/v1/models/orders.js
@@ -3,6 +3,7 @@ const order = {
 	id: 1,
 	car_id: 5,
 	car_name: 'new Volkswagen Cx4 - 2001',
+	car_body_type: 'Van',
 	price: 4500000,
 	owner_id: 2,
 	owner_name: 'Lorita M.',


### PR DESCRIPTION
#### What does this PR do?
Enable a logged-in user to view his/her purchase history

#### Description of Task to be completed?

- consume the api endpoint '/api/v1/order?user_id=user_id'
- activate the purchase history page

#### How should this be manually tested?
clone this repo,  cd to the root directory, then run this command:

- npm run dev

enter the url:

- http://localhost:3000/api/v1/signin

After you have signed in, you will be redirected to the marketplace where you can start placing orders.
After placing some orders, navigate to purchase history via the nav bar. There you will see a list of summary details for each of your purchase order.

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#166438311](https://www.pivotaltracker.com/story/show/166438311)

#### Screenshots (if appropriate)
#### Questions: