### PR TITLE
#166445492 Enable a user to mark his/her posted ad as sold

### DIFF
--- a/UI/js/my-posted-ads.js
+++ b/UI/js/my-posted-ads.js
@@ -53,6 +53,28 @@ const openUpdateModal = (params) => {
   };
 };
 
+const updateAdStatus = (car_id) => {
+  const init = {
+    method: 'PATCH',
+    body: JSON.stringify({ user_id }),
+    headers: { 'Content-Type': 'application/json' },
+  };
+  fetch(`/api/v1/car/${car_id}/status`, init)
+  .then(res => res.json())
+  .then((response) => {
+    const message = document.querySelector('#notification-overlay .message');
+    const res = response;
+    if (res.status === 201) {
+      message.innerHTML = res.message;
+    } else {
+      message.innerHTML = `${res.data}!<br/>Please ensure you are logged-in before accessing this page.<br/>
+      If you don't have an account on AutoMart,<br/><a href='/api/v1/signup'>Click here to Sign-up.</a>`;
+    }
+    updatePriceModal.style.display = 'none';
+    notificationModal.style.display = 'block';
+  });
+};
+
 const getCarDetils = (carId) => {
   fetch(`/api/v1/car/${carId}`)
   .then(res => res.json())
@@ -89,6 +111,9 @@ const getCarDetils = (carId) => {
 
       markSoldBtn.setAttribute('class', 'half-btn btn');
       markSoldBtn.innerHTML = 'Mark Sold';
+      markSoldBtn.onclick = () => {
+        updateAdStatus(id);
+      };
       deleteAdBtn.setAttribute('class', 'delete half-btn btn');
       deleteAdBtn.innerHTML = 'Delete Ad';
       if (status === 'sold') {
@@ -162,6 +187,9 @@ window.onload = () => {
         };
         markSoldBtn.setAttribute('class', 'mark-sold full-btn btn');
         markSoldBtn.innerHTML = 'Mark Sold';
+        markSoldBtn.onclick = () => {
+          updateAdStatus(id);
+        };
         if (status === 'sold') {
           updatePriceBtn.setAttribute('disabled', 'disabled');
           markSoldBtn.setAttribute('disabled', 'disabled');

--- a/UI/js/purchase-history.js
+++ b/UI/js/purchase-history.js
@@ -71,7 +71,7 @@ window.onload = () => {
       res.data.purchase_list.map((order) => {
         const {
           id, car_name, car_body_type, price, owner_name,
-          buyer_id, price_offered, created_on, status,
+          price_offered, created_on, status,
         } = order;
         const orderCard = document.createElement('li');
         const btnGrp = document.createElement('div');
@@ -97,6 +97,9 @@ window.onload = () => {
 						id, car_name, price, car_body_type, price_offered,
 					});
 				};
+        if (status !== 'pending') {
+          updateOrderBtn.setAttribute('disbled', 'disbled');
+        }
 				cancelOrderBtn.setAttribute('class', 'delete full-btn btn');
 				cancelOrderBtn.innerHTML = 'Cancel Purchase';
 

--- a/api/v1/controllers/cars.js
+++ b/api/v1/controllers/cars.js
@@ -132,7 +132,7 @@ export default {
 			if (user !== null && user.id === car.owner_id) {
 				car.status = 'sold';
 				const response = cars.updateACar(car.id, car);
-				res.status(201).send({ status: 201, data: response });
+				res.status(201).send({ status: 201, data: response, message: `Successfully marked ${car.name} as sold.` });
 			} else {
 				res.status(401).send({ status: 401, data: 'Unauthorized Access!' });
 			}


### PR DESCRIPTION
#### What does this PR do?
Enable logged-in users to update the price of their purchase order

#### Description of Task to be completed?'

- consume the api endpoint '/api/v1/car/:car_id/status'
- activate the 'Mark Sold' button

#### How should this be manually tested?

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[166445492](https://www.pivotaltracker.com/story/show/166445492)

#### Screenshots (if appropriate)
#### Questions: