### PR TITLE
#166465646 Activate the admin page

### DIFF
--- a/UI/js/admin.js
+++ b/UI/js/admin.js
@@ -1,15 +1,155 @@
-const previewAdBtns = document.querySelectorAll('.car-image');
 const carPreview = document.getElementById('car-preview-overlay');
+const notificationModal = document.getElementById('notification-overlay');
+const updatePriceModal = document.getElementById('update-price-overlay');
 const closeCarPreview = document.getElementById('close-car-preview');
+const closeNotifation = document.querySelector('.close-notification');
 
-previewAdBtns.forEach((btn) => {
-  btn.onclick = () => {
-    carPreview.style.display = 'block';
+const user_id = sessionStorage.getItem('user_id');
+const is_loggedin = sessionStorage.getItem('is_loggedin');
+const is_admin = sessionStorage.getItem('is_admin');
+
+/* ================ Helper funtions ================= */
+// used to get details of a car from the database
+const deleteAd = (car_id) => {
+  // logic to delete a posted ad
+};
+
+const getCarDetils = (carId) => {
+  fetch(`/api/v1/car/${carId}`)
+  .then(res => res.json())
+  .then((response) => {
+    if (response.status === 200) {
+      const car = response.data;
+      const {
+        id, name, img_url, manufacturer, model, year, status,
+        price, body_type, fuel_type, mileage, state, owner_name,
+        color, transmission_type, fuel_cap, created_on,
+      } = car;
+      const desc = document.querySelector('#car-preview-overlay .car-view-main-desc');
+      document.querySelector('#car-preview-overlay .modal-header').innerHTML = name;
+      document.querySelector('#car-preview-overlay .added-date').innerHTML = `Added on: ${created_on}`;
+      document.querySelector('#car-preview-overlay img').setAttribute('src', img_url);
+      desc.innerHTML = `<p class="c-price">Price: &#8358 ${price.toLocaleString('en-US')}</p>
+              <div class="prop-list flex-container">
+                <p class="prop"><b>Make:</b><br>${manufacturer}</p>
+                <p class="prop"><b>Model:</b><br>${model}</p>
+                <p class="prop"><b>Status:</b><br>${status}</p>
+                <p class="prop"><b>State:</b><br>${state}</p>
+                <p class="prop"><b>Body Type:</b><br>${body_type}</p>
+                <p class="prop"><b>Color:</b><br>${color}</p>
+                <p class="prop"><b>Year:</b><br>${year}</p>
+                <p class="prop"><b>Fuel Type:</b><br>${fuel_type}</p>
+                <p class="prop"><b>Fuel Capacity:</b><br>${fuel_cap}L</p>
+                <p class="prop"><b>Mileage:</b><br>${mileage.toLocaleString('en-US')}km</p>
+                <p class="prop"><b>Transmission:</b><br>${transmission_type}</p>
+                <p class="prop"><b>Posted By:</b><br>${owner_name}</p>
+              </div>`;
+      const btnGrp = document.createElement('div');
+      const viewFlagsBtn = document.createElement('button');
+      const deleteAdBtn = document.createElement('button');
+
+      viewFlagsBtn.setAttribute('class', 'view-reports half-btn btn');
+      viewFlagsBtn.innerHTML = 'View Flags';
+      deleteAdBtn.setAttribute('class', 'delete half-btn btn');
+      deleteAdBtn.innerHTML = 'Delete Ad';
+      deleteAdBtn.onclick = () => {
+        deleteAd(id);
+      };
+      btnGrp.setAttribute('class', 'btn-group flex-container');
+      btnGrp.appendChild(viewFlagsBtn);
+      btnGrp.appendChild(deleteAdBtn);
+      desc.appendChild(btnGrp);
+    } else {
+      const message = document.querySelector('#notification-overlay .message');
+      message.innerHTML = response.data;
+      notificationModal.style.display = 'block';
+      toggleScroll();
+    }
+  });
+};
+
+/* ==================== MAIN LOGICS ====================== */
+window.onload = () => {
+  // redirect to sign in page if the user is not logged in
+  if (!(is_loggedin || is_admin)) {
+      setTimeout(() => {
+      window.location.href = '/api/v1/signin';
+    }, 0);
+  }
+
+  // fetch the cars from database and populate the marketplace
+   fetch('/api/v1/car')
+  .then(res => res.json())
+  .then((response) => {
+    const res = response;
+    const carList = document.querySelector('.car-list');
+    if (res.data.length > 0) {
+      res.data.map((car) => {
+        const {
+          id, name, owner_name, body_type, state, status, price, img_url, created_on,
+        } = car;
+        const carCard = document.createElement('li');
+        const carImg = document.createElement('div');
+        const carInfo = document.createElement('div');
+        const btnGrp = document.createElement('div');
+        const viewFlagsBtn = document.createElement('button');
+        const deleteAdBtn = document.createElement('button');
+
+        carCard.setAttribute('class', 'car-card flex-container');
+        carImg.classList.add('car-image');
+        carImg.innerHTML = `<img src="${img_url}" title="Preview AD">
+            <label class="car-state-tag">${state}</label>`;
+        carImg.onclick = () => {
+          getCarDetils(id);
+          carPreview.style.display = 'block';
+          toggleScroll();
+        };
+        
+        carInfo.classList.add('car-info');
+        carInfo.innerHTML = `<h3 class="c-details-list">${name}</h3>
+                            <label class="car-status-tag">${status}</label>
+                            <p class="car-price">&#8358 ${price.toLocaleString('en-US')}</p>
+                            <p><b>Body type:</b> ${body_type}</p>
+                            <p>Posted by ${owner_name}, on: ${created_on}</p>`;
+        
+        viewFlagsBtn.setAttribute('class', 'view-reports full-btn btn');
+        viewFlagsBtn.innerHTML = 'View Flags';
+        deleteAdBtn.setAttribute('class', 'delete full-btn btn');
+        deleteAdBtn.innerHTML = 'Delete Ad';
+        deleteAdBtn.onclick = () => {
+          deleteAd(id);
+        };
+        btnGrp.setAttribute('class', 'admin-actions');
+        btnGrp.appendChild(viewFlagsBtn);
+        btnGrp.appendChild(deleteAdBtn);
+
+        carCard.appendChild(carImg);
+        carCard.appendChild(carInfo);
+        carCard.appendChild(btnGrp);
+        carList.appendChild(carCard);
+        return 0;
+      });
+    } else {
+      // the car list is empty
+      carList.style.textAlign = 'center';
+      carList.innerHTML = 'No car sale ad has been posted.';
+    }
+  })
+  .catch((error) => {
+    const message = document.querySelector('#notification-overlay .message');
+    message.innerHTML = error;
+    notificationModal.style.display = 'block';
     toggleScroll();
-  };
-});
+  });
+};
 
 closeCarPreview.onclick = () => {
   carPreview.style.display = 'none';
   toggleScroll();
+};
+
+closeNotifation.onclick = (e) => {
+  e.preventDefault();
+  notificationModal.style.display = 'none';
+  document.location.reload();
 };

--- a/UI/js/marketplace.js
+++ b/UI/js/marketplace.js
@@ -90,7 +90,7 @@ const getCarDetils = (carId) => {
       const car = response.data;
       const {
         id, name, img_url, manufacturer, model, year, state,
-        owner_name, price, body_type, fuel_type, mileage,
+        owner_id, owner_name, price, body_type, fuel_type, mileage,
         color, transmission_type, fuel_cap, created_on,
       } = car;
       const desc = document.querySelector('#car-preview-overlay .car-view-main-desc');
@@ -109,7 +109,7 @@ const getCarDetils = (carId) => {
                 <p class="prop"><b>Fuel Capacity:</b><br>${fuel_cap}L</p>
                 <p class="prop"><b>Mileage:</b><br>${mileage.toLocaleString('en-US')}km</p>
                 <p class="prop"><b>Transmission:</b><br>${transmission_type}</p>
-                <p class="prop"><b>Posted By:</b><br>${owner_name}</p>
+                <p class="prop"><b>Posted By:</b><br>${(owner_id === parseInt(user_id, 10) ? 'Me' : owner_name)}</p>
                 <p><a href="#">Full Details >></a></p>
               </div>`;
       const btnGrp = document.createElement('div');
@@ -117,16 +117,23 @@ const getCarDetils = (carId) => {
       const flagBtn = document.createElement('button');
       btnGrp.setAttribute('class', 'btn-group flex-container');
       orderBtn.setAttribute('class', 'half-btn btn');
-      orderBtn.onclick = () => openPurchaseModal({
-        id, name, price, body_type,
-      });
+      orderBtn.onclick = () => {
+        openPurchaseModal({
+          id, name, price, body_type,
+        });
+      };
       orderBtn.innerHTML = 'Place Order';
       flagBtn.setAttribute('class', 'half-btn btn');
-      flagBtn.onclick = () => openFraudModal({
-        id, name, price, body_type,
-      });
+      flagBtn.onclick = () => {
+        openFraudModal({
+          id, name, price, body_type,
+        });
+      };
       flagBtn.innerHTML = 'Flag Fradulent AD';
-
+      if (owner_id === parseInt(user_id, 10)) {
+        orderBtn.setAttribute('disabled', 'disabled');
+        flagBtn.setAttribute('disabled', 'disabled');
+      }
       btnGrp.appendChild(orderBtn);
       btnGrp.appendChild(flagBtn);
 
@@ -154,12 +161,12 @@ window.onload = () => {
     if (res.data.length > 0) {
       res.data.map((car) => {
         const {
-          id, name, model, body_type, manufacturer, year, state, price, img_url,
+          id, name, model, body_type, manufacturer, year, state, price, img_url, owner_id,
         } = car;
         const carCard = document.createElement('li');
         const carImg = document.createElement('div');
         const carInfo = document.createElement('div');
-        const btn = document.createElement('button');
+        const orderBtn = document.createElement('button');
         carCard.classList.add('car-card');
         carCard.setAttribute('data-id', id);
         carImg.classList.add('car-image');
@@ -169,16 +176,19 @@ window.onload = () => {
           toggleScroll();
         };
         carInfo.classList.add('car-info');
-        btn.classList.add('order', 'full-btn', 'btn');
-        btn.onclick = () => openPurchaseModal({
+        orderBtn.classList.add('order', 'full-btn', 'btn');
+        orderBtn.onclick = () => openPurchaseModal({
           id, name, price, body_type,
         });
-        btn.innerHTML = 'Place Order';
+        orderBtn.innerHTML = 'Place Order';
+        if (owner_id === parseInt(user_id, 10)) {
+          orderBtn.setAttribute('disabled', 'disabled');
+        }
         carImg.innerHTML = `<img src="${img_url}" title="Preview AD">
             <label class="car-state-tag">${state}</label>`;
         carInfo.innerHTML = `<h3 class="c-details-mv">${year} ${manufacturer}<br>${model}</h3>
             <p class="car-price">&#8358 ${price.toLocaleString('en-US')}</p>`;
-        carInfo.appendChild(btn);
+        carInfo.appendChild(orderBtn);
         carCard.appendChild(carImg);
         carCard.appendChild(carInfo);
         carList.appendChild(carCard);

--- a/UI/js/my-posted-ads.js
+++ b/UI/js/my-posted-ads.js
@@ -39,7 +39,7 @@ const openUpdateModal = (params) => {
     .then((response) => {
       const message = document.querySelector('#notification-overlay .message');
       const res = response;
-      if (res.status === 201) {
+      if (res.status === 200) {
         message.innerHTML = `You have successfully updated the price for <b>${res.data.name}.</b><br/><br/>
         Old Price: &#8358 ${price.toLocaleString('en-US')}<br/>
         New Price: &#8358 ${res.data.price.toLocaleString('en-US')}`;
@@ -64,7 +64,7 @@ const updateAdStatus = (car_id) => {
   .then((response) => {
     const message = document.querySelector('#notification-overlay .message');
     const res = response;
-    if (res.status === 201) {
+    if (res.status === 200) {
       message.innerHTML = res.message;
     } else {
       message.innerHTML = `${res.data}!<br/>Please ensure you are logged-in before accessing this page.<br/>

--- a/UI/template/admin.html
+++ b/UI/template/admin.html
@@ -185,7 +185,7 @@
 				<main class="main-75">
 					<h2>All Posted ADs by Users</h2>
 					<ul class="car-list">
-						<li class="car-card flex-container">
+						<!-- <li class="car-card flex-container">
 							<div class="car-image">
 								<img src="/images/car-samples/car-sample-1.jpg" title="Preview AD">
 								<label class="car-state-tag">New</label>
@@ -200,63 +200,10 @@
 							</div>
 							<div class="admin-actions">
 								<button class="view-reports full-btn btn">View Reports</button>
-								<button class="delete order full-btn btn">Delete AD</button>
+								<button class="delete full-btn btn">Delete AD</button>
 							</div>
 						</li>
-						<li class="car-card flex-container">
-							<div class="car-image">
-								<img src="/images/car-samples/car-sample-2.jpg" title="Preview AD">
-								<label class="car-state-tag">Used</label>
-							</div>
-							<div class="car-info">
-								<h3 class="c-details-list">2010 Honda CX422</h3>
-								<label class="car-status-tag">Unsold</label>
-								<p class="car-price">&#8358 5,200,000</p>
-								<p><b>Body type:</b> Salon Car</p>
-								<p>Posted by: Stephen D.<span>, on: 23-April-2019 12:45am</span></p>
-								
-							</div>
-							<div class="admin-actions">
-								<button class="view-reports full-btn btn">View Reports</button>
-								<button class="delete order full-btn btn">Delete AD</button>
-							</div>
-						</li>
-						<li class="car-card flex-container">
-							<div class="car-image">
-								<img src="/images/car-samples/car-sample-3.jpg" title="Preview AD">
-								<label class="car-state-tag">Used</label>
-							</div>
-							<div class="car-info">
-								<h3 class="c-details-list">2010 Honda CX422</h3>
-								<label class="car-status-tag">Unsold</label>
-								<p class="car-price">&#8358 5,200,000</p>
-								<p><b>Body type:</b> Salon Car</p>
-								<p>Posted by: Stephen D.<span>, on: 23-April-2019 12:45am</span></p>
-								
-							</div>
-							<div class="admin-actions">
-								<button class="view-reports full-btn btn">View Reports</button>
-								<button class="delete order full-btn btn">Delete AD</button>
-							</div>
-						</li>
-						<li class="car-card flex-container">
-							<div class="car-image">
-								<img src="/images/car-samples/car-sample-4.jpg" title="Preview AD">
-								<label class="car-state-tag">New</label>
-							</div>
-							<div class="car-info">
-								<h3 class="c-details-list">2010 Honda CX422</h3>
-								<label class="car-status-tag">Sold</label>
-								<p class="car-price">&#8358 5,200,000</p>
-								<p><b>Body type:</b> Salon Car</p>
-								<p>Posted by: Stephen D.<span>, on: 23-April-2019 12:45am</span></p>
-								
-							</div>
-							<div class="admin-actions">
-								<button class="view-reports full-btn btn">View Reports</button>
-								<button class="delete order full-btn btn">Delete AD</button>
-							</div>
-						</li>
+						 -->
 					</ul>
 				</main>
 			</div>
@@ -278,18 +225,18 @@
 		</div>
 
 		<!-- Modal view to view a specific car -->
-		<div id="car-preview-overlay" class="overlay" style="display: none">
+		<div id="car-preview-overlay" class="overlay">
 			<div class="lg-m-v">
-				<h2 class="modal-header">New Volkswagen Cx3 - 2001</h2>
-				<p class="added-date">Added: 12-Jan-2019 3:23pm</p>
+				<h2 class="modal-header"></h2>
+				<p class="added-date"></p>
 				<div id="close-car-preview" class="fa fa-times close-btn"></div>
 				<div class="modal-body">
 					<div class="car-view-detail flex-container">
 						<div class="car-view-image">
-							<img src="/images/car-samples/car-sample-10.jpg">
+							<img src="">
 						</div>
 						<div class="car-view-main-desc">
-							<p class="c-price">Price: &#8358 23,000,000</p>
+							<!-- <p class="c-price">Price: &#8358 23,000,000</p>
 							<div class="prop-list flex-container">
 								<p class="prop"><b>Make:</b><br>Volkswagen</p>
 								<p class="prop"><b>Model:</b><br>Cx3</p>
@@ -302,12 +249,12 @@
 								<p class="prop"><b>Mileage:</b><br>74,544km</p>
 								<p class="prop"><b>Transmission:</b><br>Automatic</p>
 								<p class="prop"><b>Engine Detail:</b><br>2.8 Turbo Diesel</p>
-								<p class="prop"><b>Owner:</b><br>John Chibuike</p>
+								<p><a href="#">Full Details >></a></p>
 							</div>
 							<div class="btn-group flex-container">
-								<button class="view-reports half-btn btn">View Reports</button>
-								<button class="delete half-btn btn">Delete AD</button>
-							</div>
+								<button id="order-from-car-preview" class="half-btn btn">Place Order</button>
+								<button id="flag-fraud" class="half-btn btn">Flag Fradulent AD</button>
+							</div> -->
 						</div>
 					</div>
 				</div>

--- a/api/v1/controllers/cars.js
+++ b/api/v1/controllers/cars.js
@@ -116,7 +116,7 @@ export default {
 			if (user !== null && user.id === car.owner_id) {
 				car.price = new_price;
 				const response = cars.updateACar(car.id, car);
-				res.status(201).send({ status: 201, data: response });
+				res.status(200).send({ status: 200, data: response });
 			} else {
 				res.status(401).send({ status: 401, data: 'Unauthorized Access!' });
 			}
@@ -132,7 +132,9 @@ export default {
 			if (user !== null && user.id === car.owner_id) {
 				car.status = 'sold';
 				const response = cars.updateACar(car.id, car);
-				res.status(201).send({ status: 201, data: response, message: `Successfully marked ${car.name} as sold.` });
+				res.status(200).send({
+					status: 200, data: response, message: `You have successfully marked<br><b>${car.name}</b><br>as sold.`,
+				});
 			} else {
 				res.status(401).send({ status: 401, data: 'Unauthorized Access!' });
 			}

--- a/api/v1/controllers/orders.js
+++ b/api/v1/controllers/orders.js
@@ -80,7 +80,7 @@ export default {
 					response.new_price_offered = new_price;
 					delete response.price_offered;
 				}
-				res.status(201).send({ status: 201, data: response });
+				res.status(200).send({ status: 200, data: response });
 			} else {
 				res.status(401).send({ status: 401, data: 'Unauthorized Access!' });
 			}

--- a/tests/carsTest.js
+++ b/tests/carsTest.js
@@ -183,7 +183,7 @@ describe('Testing the car sale ads endpoints', () => {
 		.patch('/api/v1/car/1/price').send({ user_id: 3, new_price: 20000000 })
 		.end((err, res) => {
 			const { data } = res.body;
-			res.should.have.status(201);
+			res.should.have.status(200);
 			expect(data).to.include({
 				price: 20000000,
 				id: 1,
@@ -197,7 +197,7 @@ describe('Testing the car sale ads endpoints', () => {
 		.patch('/api/v1/car/4/status').send({ user_id: 3 })
 		.end((err, res) => {
 			const { data } = res.body;
-			res.should.have.status(201);
+			res.should.have.status(200);
 			expect(data).to.include({
 				status: 'sold',
 				id: 4,

--- a/tests/ordersTest.js
+++ b/tests/ordersTest.js
@@ -52,7 +52,7 @@ describe('Tests for the orders api endpoints', () => {
 		.patch('/api/v1/order/1/price').send({ buyer_id: 2, new_price: 1500000 })
 		.end((err, res) => {
 			const { data } = res.body;
-			res.should.have.status(201);
+			res.should.have.status(200);
 			expect(data).to.include({
 				old_price_offered: data.old_price_offered,
 				new_price_offered: 1500000,


### PR DESCRIPTION
#### What does this PR do?
Enable registered admins to log into the admin page and view all the posted ads whether sold or unsold

#### Description of Task to be completed?'

- allow admin to log into the admin page
- consume the api endpoint '/api/v1/car' to get all car ads whether sold or unsold
- enable the admin to preview the car ad by clicking on the ad image

#### How should this be manually tested?
clone this repo, cd to the root directory, then run this command:

- npm run dev

When the server starts running, enter the url:

- http://localhost:3000/api/v1/signin

Sign in with an admin account. The admin page will load up where you can view all the posted car ads

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#166465646](https://www.pivotaltracker.com/story/show/166465646)

#### Screenshots (if appropriate)
#### Questions: